### PR TITLE
Several of changes to reproduce the accuracy in the paper

### DIFF
--- a/example.py
+++ b/example.py
@@ -28,5 +28,5 @@ def get_mnist():
 X, Y  = get_mnist()
 
 c = DeepEmbeddingClustering(n_clusters=10, input_dim=784)
-c.initialize(X, epochs=10)
+c.initialize(X, finetune_iters=1, layerwise_pretrain_iters=1)
 c.cluster(X, y=Y)

--- a/example.py
+++ b/example.py
@@ -1,6 +1,6 @@
-from Keras_dec import DeepEmbeddingClustering
+from keras_dec import DeepEmbeddingClustering
 from keras.datasets import mnist
-
+import numpy as np
 
 def preproc(X):
     # 1/d * ||x_i||2**2 = 1.0
@@ -14,5 +14,5 @@ X_train = preproc(X_train)
 X_test = preproc(X_test)
 
 c = DeepEmbeddingClustering(n_clusters=10, input_dim=784)
-c.initialize(X_train, nb_epoch=100)
-c.cluster(X_train, y=y_train)
+c.initialize(X_train, epochs=60)
+c.cluster(X_train, y=y_train, iter_max = 20000)

--- a/example.py
+++ b/example.py
@@ -28,5 +28,5 @@ def get_mnist():
 X, Y  = get_mnist()
 
 c = DeepEmbeddingClustering(n_clusters=10, input_dim=784)
-c.initialize(X, finetune_iters=100000, layerwise_pretrain_iters=500000)
+c.initialize(X, finetune_iters=100000, layerwise_pretrain_iters=50000)
 c.cluster(X, y=Y)

--- a/example.py
+++ b/example.py
@@ -14,5 +14,5 @@ X_train = preproc(X_train)
 X_test = preproc(X_test)
 
 c = DeepEmbeddingClustering(n_clusters=10, input_dim=784)
-c.initialize(X_train, epochs=60)
-c.cluster(X_train, y=y_train, iter_max = 20000)
+c.initialize(X_train, epochs=100)
+c.cluster(X_train, y=y_train)

--- a/example.py
+++ b/example.py
@@ -6,13 +6,27 @@ def preproc(X):
     # 1/d * ||x_i||2**2 = 1.0
     return (X.T / X.mean(1)).T
 
-(X_train, y_train), (X_test, y_test) = mnist.load_data()
-X_train = np.asarray([x.flatten() for x in X_train], dtype='float32')
-X_test = np.asarray([x.flatten() for x in X_test], dtype='float32')
+def get_mnist():
+    np.random.seed(1234) # set seed for deterministic ordering
+    (x_train, y_train), (x_test, y_test) = mnist.load_data()
+    x_all = np.concatenate((x_train, x_test), axis = 0)
+    Y = np.concatenate((y_train, y_test), axis = 0)
+    X = x_all.reshape(-1,x_all.shape[1]*x_all.shape[2])
+    
+    p = np.random.permutation(X.shape[0])
+    X = X[p].astype(np.float32)*0.02
+    Y = Y[p]
+    return X, Y
 
-X_train = preproc(X_train)
-X_test = preproc(X_test)
+
+#X_train = np.asarray([x.flatten() for x in X_train], dtype='float32')
+#X_test = np.asarray([x.flatten() for x in X_test], dtype='float32')
+
+#X_train = preproc(X_train)
+#X_test = preproc(X_test)
+
+X, Y  = get_mnist()
 
 c = DeepEmbeddingClustering(n_clusters=10, input_dim=784)
-c.initialize(X_train, epochs=100)
-c.cluster(X_train, y=y_train)
+c.initialize(X, epochs=10)
+c.cluster(X, y=Y)

--- a/example.py
+++ b/example.py
@@ -2,9 +2,6 @@ from keras_dec import DeepEmbeddingClustering
 from keras.datasets import mnist
 import numpy as np
 
-def preproc(X):
-    # 1/d * ||x_i||2**2 = 1.0
-    return (X.T / X.mean(1)).T
 
 def get_mnist():
     np.random.seed(1234) # set seed for deterministic ordering
@@ -18,12 +15,6 @@ def get_mnist():
     Y = Y[p]
     return X, Y
 
-
-#X_train = np.asarray([x.flatten() for x in X_train], dtype='float32')
-#X_test = np.asarray([x.flatten() for x in X_test], dtype='float32')
-
-#X_train = preproc(X_train)
-#X_test = preproc(X_test)
 
 X, Y  = get_mnist()
 

--- a/example.py
+++ b/example.py
@@ -28,5 +28,5 @@ def get_mnist():
 X, Y  = get_mnist()
 
 c = DeepEmbeddingClustering(n_clusters=10, input_dim=784)
-c.initialize(X, finetune_iters=1, layerwise_pretrain_iters=1)
+c.initialize(X, finetune_iters=100000, layerwise_pretrain_iters=500000)
 c.cluster(X, y=Y)

--- a/keras_dec.py
+++ b/keras_dec.py
@@ -138,12 +138,12 @@ class DeepEmbeddingClustering(object):
 
     def initialize(self, X, save_autoencoder=False, **kwargs):
         if self.pretrained_weights is None:
-            print 'Training autoencoder.'
+            print('Training autoencoder.')
             self.autoencoder.fit(X, X, batch_size=self.batch_size, **kwargs)
             if save_autoencoder:
                 self.autoencoder.save_weights('autoencoder.h5')
         else:
-            print 'Loading pretrained weights for autoencoder.'
+            print('Loading pretrained weights for autoencoder.')
             self.autoencoder.load_weights(self.pretrained_weights)
 
         # update encoder, decoder
@@ -151,7 +151,7 @@ class DeepEmbeddingClustering(object):
             self.encoder.layers[i].set_weights(self.autoencoder.layers[i].get_weights())
 
         # initialize cluster centres using k-means
-        print 'Initializing cluster centres with k-means.'
+        print('Initializing cluster centres with k-means.')
         if self.cluster_centres is None:
             kmeans = KMeans(n_clusters=self.n_clusters, n_init=50)
             self.y_pred = kmeans.fit_predict(self.encoder.predict(X))
@@ -183,12 +183,12 @@ class DeepEmbeddingClustering(object):
         if update_interval is None:
             # 1 epochs
             update_interval = X.shape[0]/self.batch_size
-        print 'Update interval', update_interval
+        print('Update interval', update_interval)
 
         if save_interval is None:
             # 50 epochs
             save_interval = X.shape[0]/self.batch_size*50
-        print 'Save interval', save_interval
+        print('Save interval', save_interval)
 
         assert save_interval >= update_interval
 
@@ -201,7 +201,7 @@ class DeepEmbeddingClustering(object):
             sys.stdout.write('\r')
             # cutoff iteration
             if iter_max < iteration:
-                print 'Reached maximum iteration limit. Stopping training.'
+                print('Reached maximum iteration limit. Stopping training.')
                 return
 
             # update (or initialize) probability distributions and propagate weight changes
@@ -215,12 +215,12 @@ class DeepEmbeddingClustering(object):
                 if y is not None:
                     acc = self.cluster_acc(y, y_pred)[0]
                     self.accuracy.append(acc)
-                    print 'Iteration '+str(iteration)+', Accuracy '+str(np.round(acc, 5))
+                    print('Iteration '+str(iteration)+', Accuracy '+str(np.round(acc, 5)))
                 else:
-                    print str(np.round(delta_label*100, 5))+'% change in label assignment'
+                    print(str(np.round(delta_label*100, 5))+'% change in label assignment')
 
                 if delta_label < tol:
-                    print 'Reached tolerance threshold. Stopping training.'
+                    print('Reached tolerance threshold. Stopping training.')
                     train = False
                     continue
                 else:

--- a/keras_dec.py
+++ b/keras_dec.py
@@ -184,7 +184,6 @@ class DeepEmbeddingClustering(object):
                 initial_rate = self.learning_rate
                 factor = int(epoch / lr_epoch_update)
                 lr = initial_rate / (10 ** factor)
-                print("Setting LR to %s"%lr)
                 return lr
             lr_schedule = LearningRateScheduler(step_decay)
 
@@ -274,7 +273,7 @@ class DeepEmbeddingClustering(object):
             # cutoff iteration
             if iter_max < iteration:
                 print('Reached maximum iteration limit. Stopping training.')
-                return
+                return self.y_pred
 
             # update (or initialize) probability distributions and propagate weight changes
             # from DEC model to encoder.

--- a/keras_dec.py
+++ b/keras_dec.py
@@ -16,8 +16,7 @@ from sklearn.utils.linear_assignment_ import linear_assignment
 from sklearn.cluster import KMeans
 from sklearn.decomposition import PCA
 import cPickle as pickle
-from DEC import ClusteringLayer
-
+import numpy as np
 
 class ClusteringLayer(Layer):
     '''
@@ -61,9 +60,9 @@ class ClusteringLayer(Layer):
         self.trainable_weights = [self.W]
 
     def call(self, x, mask=None):
-        q = 1.0/(1.0 + K.sqrt((K.square(K.expand_dims(x, dim=1) - self.W).sum(axis=2)))**2 /self.alpha)
+        q = 1.0/(1.0 + K.sqrt(K.sum(K.square(K.expand_dims(x, 1) - self.W), axis=2))**2 /self.alpha)
         q = q**((self.alpha+1.0)/2.0)
-        q = (q.T/q.sum(axis=1)).T
+        q = K.transpose(K.transpose(q)/K.sum(q, axis=1))
         return q
 
     def get_output_shape_for(self, input_shape):

--- a/keras_dec.py
+++ b/keras_dec.py
@@ -183,7 +183,6 @@ class DeepEmbeddingClustering(object):
             def step_decay(epoch):
                 initial_rate = self.learning_rate
                 factor = int(epoch / lr_epoch_update)
-                print("epoch %d, factor %d"%(epoch, factor))
                 lr = initial_rate / (10 ** factor)
                 print("Setting LR to %s"%lr)
                 return lr
@@ -205,8 +204,8 @@ class DeepEmbeddingClustering(object):
                 self.autoencoder.layers[len(self.autoencoder.layers) - i - 1].set_weights(autoencoder.layers[-1].get_weights())
             
             print('Finetuning autoencoder')
+            
             #update encoder and decoder weights:
-
             self.autoencoder.fit(X, X, batch_size=self.batch_size, epochs=finetune_epochs, callbacks=[lr_schedule])
 
             if save_autoencoder:

--- a/keras_dec.py
+++ b/keras_dec.py
@@ -15,7 +15,10 @@ from sklearn.preprocessing import normalize
 from sklearn.utils.linear_assignment_ import linear_assignment
 from sklearn.cluster import KMeans
 from sklearn.decomposition import PCA
-import cPickle as pickle
+if (sys.version[0] == 2):
+    import cPickle as pickle
+else:
+    import pickle
 import numpy as np
 
 class ClusteringLayer(Layer):

--- a/keras_dec.py
+++ b/keras_dec.py
@@ -72,6 +72,10 @@ class ClusteringLayer(Layer):
         assert input_shape and len(input_shape) == 2
         return (input_shape[0], self.output_dim)
 
+    def compute_output_shape(self, input_shape):
+        assert input_shape and len(input_shape) == 2
+        return (input_shape[0], self.output_dim)
+
     def get_config(self):
         config = {'output_dim': self.output_dim,
                   'input_dim': self.input_dim}
@@ -113,7 +117,7 @@ class DeepEmbeddingClustering(object):
             self.encoded = Dense(2000, activation='relu', name='encoder_dense_3')(self.encoded)
             self.encoded = Dropout(dropout_fraction, name='encoder_dropout_3')(self.encoded)
             self.encoded = Dense(10, activation='linear', name='encoder_dense_4')(self.encoded)
-        self.encoder = Model(input=self.input_layer, output=self.encoded)
+        self.encoder = Model(inputs=self.input_layer, outputs=self.encoded)
 
         if self.decoded is None:
             self.decoded = Dense(2000, activation='relu', name='decoder_dense_1')(self.encoded)
@@ -123,7 +127,7 @@ class DeepEmbeddingClustering(object):
             self.decoded = Dense(500, activation='relu', name='decoder_dense_3')(self.decoded)
             self.decoded = Dropout(dropout_fraction, name='decoder_dropout_3')(self.decoded)
             self.decoded = Dense(784, activation='linear', name='decoder_dense_4')(self.decoded)
-        self.autoencoder = Model(input=self.input_layer, output=self.decoded)
+        self.autoencoder = Model(inputs=self.input_layer, outputs=self.decoded)
 
         if cluster_centres is not None:
             assert cluster_centres.shape[0] == self.n_clusters
@@ -161,8 +165,8 @@ class DeepEmbeddingClustering(object):
             self.cluster_centres = kmeans.cluster_centers_
 
         # prepare DEC model
-        self.DEC = Model(input=self.input_layer,
-                         output=ClusteringLayer(self.n_clusters,
+        self.DEC = Model(inputs=self.input_layer,
+                         outputs=ClusteringLayer(self.n_clusters,
                                                 weights=self.cluster_centres,
                                                 name='clustering')(self.encoded))
         self.DEC.compile(loss='kullback_leibler_divergence', optimizer='adadelta')

--- a/keras_dec.py
+++ b/keras_dec.py
@@ -253,7 +253,7 @@ class DeepEmbeddingClustering(object):
                 clust_2d = pca.transform(self.cluster_centres)
                 # save states for visualization
                 pickle.dump({'z_2d': z_2d, 'clust_2d': clust_2d, 'q': self.q, 'p': self.p},
-                            open('c'+str(iteration)+'.pkl', 'w'))
+                            open('c'+str(iteration)+'.pkl', 'wb'))
                 # save DEC model checkpoints
                 self.DEC.save('DEC_model_'+str(iteration)+'.h5')
 

--- a/keras_dec.py
+++ b/keras_dec.py
@@ -196,7 +196,7 @@ class DeepEmbeddingClustering(object):
         assert save_interval >= update_interval
 
         train = True
-        shuffled = np.random.shuffle(range(X.shape[0]))
+        shuffled = np.random.shuffle(np.ndarray(range(X.shape[0])))
         iteration, index = 0, 0
         self.accuracy = []
 

--- a/keras_dec.py
+++ b/keras_dec.py
@@ -196,7 +196,7 @@ class DeepEmbeddingClustering(object):
         assert save_interval >= update_interval
 
         train = True
-        shuffled = np.random.shuffle(np.ndarray(range(X.shape[0])))
+        shuffled = np.random.shuffle(np.array(range(X.shape[0])))
         iteration, index = 0, 0
         self.accuracy = []
 


### PR DESCRIPTION
Hi,
In this PR I introduce the following changes according to the paper:
1. Layer wise pre-training for the encoder.
2. Removal of Dropout after layerwise pretraining
3. Changed optimizer to SGD with same parameters as MXNET
4. Added learning rate scheduler according to paper
4. Use the notion of "iterations" like paper instead of epochs. In MXNET every iteration basically means a forward (and backward) pass on a batch.  I'm not sure if this is really necessary. Can probably change back to epochs in the future, but for now I've done it in order to match the paper.